### PR TITLE
Migrate Function App to OpenTelemetry-based monitoring

### DIFF
--- a/src/functionApp/TrackAvailabilityInAppInsights.FunctionApp.Tests/ServiceProviderTests.cs
+++ b/src/functionApp/TrackAvailabilityInAppInsights.FunctionApp.Tests/ServiceProviderTests.cs
@@ -25,6 +25,9 @@ namespace TrackAvailabilityInAppInsights.FunctionApp.Tests
             configuration["ApiManagement__StatusEndpoint"] = "status-0123456789abcdef";
             services.AddSingleton<IConfiguration>(configuration);
 
+            // Configure the app insights connection string as an environment variable
+            Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://dc.applicationinsights.azure.com/;LiveEndpoint=https://live.applicationinsights.azure.com/;ApplicationId=00000000-0000-0000-0000-000000000000");
+
             // Register the Azure Function App depencencies
             services.RegisterDependencies();
 

--- a/src/functionApp/TrackAvailabilityInAppInsights.FunctionApp/Program.cs
+++ b/src/functionApp/TrackAvailabilityInAppInsights.FunctionApp/Program.cs
@@ -9,19 +9,13 @@ var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
-builder.Services.RegisterDependencies();
-
-builder.Logging.Services.Configure<LoggerFilterOptions>(options =>
+builder.Logging.AddOpenTelemetry(logging =>
 {
-    // The Application Insights SDK adds a default logging filter that instructs ILogger to capture only Warning and more severe logs. Application Insights requires an explicit override.
-    // Log levels can also be configured using appsettings.json. For more information, see https://learn.microsoft.com/azure/azure-monitor/app/worker-service#ilogger-logs
-    LoggerFilterRule? defaultRule = options.Rules?.FirstOrDefault(rule => rule.ProviderName
-        == "Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider");
-
-    if (defaultRule is not null && options.Rules is not null)
-    {
-        options.Rules.Remove(defaultRule);
-    }
+    logging.IncludeFormattedMessage = true;
+    logging.IncludeScopes = true;
 });
+
+builder.Services.ConfigureOpenTelemetry();
+builder.Services.RegisterDependencies();
 
 builder.Build().Run();

--- a/src/functionApp/TrackAvailabilityInAppInsights.FunctionApp/ServiceCollectionExtensions.cs
+++ b/src/functionApp/TrackAvailabilityInAppInsights.FunctionApp/ServiceCollectionExtensions.cs
@@ -26,10 +26,8 @@ namespace TrackAvailabilityInAppInsights.FunctionApp
 
             services.AddOpenTelemetry().UseAzureMonitorExporter(options =>
             {
-                // Set the Azure Monitor credential to the DefaultAzureCredential.
-                // This credential will use the Azure identity of the current user or
-                // the service principal that the application is running as to authenticate
-                // to Azure Monitor.
+                // Use the system-assigned managed identity to authenticate to Azure Monitor.
+                // See https://learn.microsoft.com/en-us/azure/azure-monitor/app/azure-ad-authentication for more details.
                 options.Credential = new ManagedIdentityCredential(new ManagedIdentityCredentialOptions());
             });
 
@@ -68,8 +66,8 @@ namespace TrackAvailabilityInAppInsights.FunctionApp
                 TelemetryChannel = new InMemoryChannel()
             };
 
-            // Use Managed Identity to authenticate with Application Insights
-            // See https://learn.microsoft.com/en-us/azure/azure-monitor/app/azure-ad-authentication for more details
+            // Use the system-assigned managed identity to authenticate to Azure Monitor.
+            // See https://learn.microsoft.com/en-us/azure/azure-monitor/app/azure-ad-authentication for more details.
             telemetryConfiguration.SetAzureTokenCredential(new ManagedIdentityCredential(new ManagedIdentityCredentialOptions()));
 
             TelemetryClient telemetryClient = new(telemetryConfiguration);

--- a/src/functionApp/TrackAvailabilityInAppInsights.FunctionApp/ServiceCollectionExtensions.cs
+++ b/src/functionApp/TrackAvailabilityInAppInsights.FunctionApp/ServiceCollectionExtensions.cs
@@ -1,7 +1,15 @@
-using Microsoft.Azure.Functions.Worker;
+using Azure.Identity;
+using Azure.Monitor.OpenTelemetry.Exporter;
+
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Azure.Functions.Worker.OpenTelemetry;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+
+using OpenTelemetry.Trace;
 
 using TrackAvailabilityInAppInsights.FunctionApp.AvailabilityTests;
 
@@ -9,10 +17,30 @@ namespace TrackAvailabilityInAppInsights.FunctionApp
 {
     internal static class ServiceCollectionExtensions
     {
+        public static IServiceCollection ConfigureOpenTelemetry(this IServiceCollection services)
+        {
+            services.AddOpenTelemetry()
+                .WithTracing(tracing => tracing
+                    // Enables HttpClient instrumentation.
+                    .AddHttpClientInstrumentation());
+
+            services.AddOpenTelemetry().UseAzureMonitorExporter(options =>
+            {
+                // Set the Azure Monitor credential to the DefaultAzureCredential.
+                // This credential will use the Azure identity of the current user or
+                // the service principal that the application is running as to authenticate
+                // to Azure Monitor.
+                options.Credential = new ManagedIdentityCredential(new ManagedIdentityCredentialOptions());
+            });
+
+            services.AddOpenTelemetry().UseFunctionsWorkerDefaults();
+
+            return services;
+        }
+
         public static IServiceCollection RegisterDependencies(this IServiceCollection services)
         {
-            services.AddApplicationInsightsTelemetryWorkerService()
-                    .ConfigureFunctionsApplicationInsights();
+            services.RegisterTelemetryClient();
 
             services.AddOptionsWithValidateOnStart<ApiManagementOptions>()
                     .BindConfiguration(ApiManagementOptions.SectionKey)
@@ -28,6 +56,25 @@ namespace TrackAvailabilityInAppInsights.FunctionApp
                 client.BaseAddress = new Uri(options.GatewayUrl);
                 client.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", options.SubscriptionKey);
             });
+
+            return services;
+        }
+
+        private static IServiceCollection RegisterTelemetryClient(this IServiceCollection services)
+        {
+            TelemetryConfiguration telemetryConfiguration = new()
+            {
+                ConnectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING"),
+                TelemetryChannel = new InMemoryChannel()
+            };
+
+            // Use Managed Identity to authenticate with Application Insights
+            // See https://learn.microsoft.com/en-us/azure/azure-monitor/app/azure-ad-authentication for more details
+            telemetryConfiguration.SetAzureTokenCredential(new ManagedIdentityCredential(new ManagedIdentityCredentialOptions()));
+
+            TelemetryClient telemetryClient = new(telemetryConfiguration);
+
+            services.AddSingleton(telemetryClient);
 
             return services;
         }

--- a/src/functionApp/TrackAvailabilityInAppInsights.FunctionApp/TrackAvailabilityInAppInsights.FunctionApp.csproj
+++ b/src/functionApp/TrackAvailabilityInAppInsights.FunctionApp/TrackAvailabilityInAppInsights.FunctionApp.csproj
@@ -11,13 +11,16 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Azure.Identity" Version="1.19.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.6.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.50.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/functionApp/TrackAvailabilityInAppInsights.FunctionApp/host.json
+++ b/src/functionApp/TrackAvailabilityInAppInsights.FunctionApp/host.json
@@ -1,12 +1,11 @@
 {
   "version": "2.0",
+  "telemetryMode": "OpenTelemetry",
   "logging": {
-    "applicationInsights": {
-      "samplingSettings": {
-        "isEnabled": true,
-        "excludedTypes": "Request"
-      },
-      "enableLiveMetricsFilters": true
+    "OpenTelemetry": {
+      "logLevel": {
+        "default": "Warning"
+      }
     }
   }
 }


### PR DESCRIPTION
Background: Version 3.0.0 of `Microsoft.ApplicationInsights.WorkerService` is not compatible with the Azure Functions Worker. There will not be a fix. Instead, migrating to OpenTelemetry-based monitoring is advised.