### PR TITLE
Use roleDefinitions function when assigning roles

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -19,4 +19,4 @@ services:
         run: ../../hooks/prepackage-logicapp-build-functions-project.ps1
         interactive: true
 requiredVersions:
-  azd: ">= 1.17.0" # azd version 1.17.0 or later is required because of the new bicep linter rule 'no-unused-imports'.
+  azd: ">= 1.23.15" # azd version 1.23.15 or higher is required because we're using features from Bicep 0.42.1.

--- a/infra/modules/shared/assign-roles-to-principal.bicep
+++ b/infra/modules/shared/assign-roles-to-principal.bicep
@@ -29,20 +29,18 @@ param storageAccountName string = ''
 // Variables
 //=============================================================================
 
-var keyVaultRole string = isAdmin
-  ? '00482a5a-887f-4fb3-b363-3b7fe8e74483' // Key Vault Administrator
-  : '4633458b-17de-408a-b874-0445c86b69e6' // Key Vault Secrets User
+var keyVaultRole string = isAdmin ? 'Key Vault Administrator' : 'Key Vault Secrets User'
 
 var storageAccountRoles string[] = [
-  'ba92f5b4-2d11-453d-a403-e96b0029c9fe' // Storage Blob Data Contributor
+  'Storage Blob Data Contributor'
   isAdmin
-    ? '69566ab7-960f-475b-8e7c-b3118f30c6bd' // Storage File Data Privileged Contributor (is able to browse file shares in Azure Portal)
-    : '0c867c2a-1d8c-454a-a3db-ab2ea1bdc8bb' // Storage File Data SMB Share Contributor
-  '974c5e8b-45b9-4653-ba55-5f855dd0fb88' // Storage Queue Data Contributor
-  '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3' // Storage Table Data Contributor
+    ? 'Storage File Data Privileged Contributor' // is able to browse file shares in Azure Portal
+    : 'Storage File Data SMB Share Contributor'
+  'Storage Queue Data Contributor'
+  'Storage Table Data Contributor'
 ]
 
-var monitoringMetricsPublisher string = '3913510d-42f4-4e42-8a64-420c390055eb' // Monitoring Metrics Publisher
+var monitoringMetricsPublisher string = 'Monitoring Metrics Publisher'
 
 //=============================================================================
 // Existing Resources
@@ -67,14 +65,11 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2025-08-01' existing 
 // Assign role Application Insights to the principal
 
 resource assignAppInsightRolesToPrincipal 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(
-    principalId,
-    appInsights.id,
-    subscriptionResourceId('Microsoft.Authorization/roleDefinitions', monitoringMetricsPublisher)
-  )
+  name: guid(principalId, appInsights.id, roleDefinitions(monitoringMetricsPublisher).id)
   scope: appInsights
   properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', monitoringMetricsPublisher)
+    #disable-next-line use-resource-id-functions
+    roleDefinitionId: roleDefinitions(monitoringMetricsPublisher).id
     principalId: principalId
     principalType: principalType
   }
@@ -83,10 +78,11 @@ resource assignAppInsightRolesToPrincipal 'Microsoft.Authorization/roleAssignmen
 // Assign role on Key Vault to the principal
 
 resource assignRolesOnKeyVaultToManagedIdentity 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(principalId, keyVault.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultRole))
+  name: guid(principalId, keyVault.id, roleDefinitions(keyVaultRole).id)
   scope: keyVault
   properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultRole)
+    #disable-next-line use-resource-id-functions
+    roleDefinitionId: roleDefinitions(keyVaultRole).id
     principalId: principalId
     principalType: principalType
   }
@@ -96,10 +92,11 @@ resource assignRolesOnKeyVaultToManagedIdentity 'Microsoft.Authorization/roleAss
 
 resource assignRolesOnStorageAccountToManagedIdentity 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
   for role in storageAccountRoles: if (storageAccountName != '') {
-    name: guid(principalId, storageAccount.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', role))
+    name: guid(principalId, storageAccount.id, roleDefinitions(role).id)
     scope: storageAccount
     properties: {
-      roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', role)
+      #disable-next-line use-resource-id-functions
+      roleDefinitionId: roleDefinitions(role).id
       principalId: principalId
       principalType: principalType
     }

--- a/infra/modules/shared/assign-roles-to-principal.bicep
+++ b/infra/modules/shared/assign-roles-to-principal.bicep
@@ -29,9 +29,9 @@ param storageAccountName string = ''
 // Variables
 //=============================================================================
 
-var keyVaultRole string = isAdmin ? 'Key Vault Administrator' : 'Key Vault Secrets User'
+var keyVaultRoleName string = isAdmin ? 'Key Vault Administrator' : 'Key Vault Secrets User'
 
-var storageAccountRoles string[] = [
+var storageAccountRoleNames string[] = [
   'Storage Blob Data Contributor'
   isAdmin
     ? 'Storage File Data Privileged Contributor' // is able to browse file shares in Azure Portal
@@ -40,7 +40,7 @@ var storageAccountRoles string[] = [
   'Storage Table Data Contributor'
 ]
 
-var monitoringMetricsPublisher string = 'Monitoring Metrics Publisher'
+var monitoringMetricsPublisherRoleName string = 'Monitoring Metrics Publisher'
 
 //=============================================================================
 // Existing Resources
@@ -65,11 +65,11 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2025-08-01' existing 
 // Assign role Application Insights to the principal
 
 resource assignAppInsightRolesToPrincipal 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(principalId, appInsights.id, roleDefinitions(monitoringMetricsPublisher).id)
+  name: guid(principalId, appInsights.id, roleDefinitions(monitoringMetricsPublisherRoleName).id)
   scope: appInsights
   properties: {
     #disable-next-line use-resource-id-functions
-    roleDefinitionId: roleDefinitions(monitoringMetricsPublisher).id
+    roleDefinitionId: roleDefinitions(monitoringMetricsPublisherRoleName).id
     principalId: principalId
     principalType: principalType
   }
@@ -78,11 +78,11 @@ resource assignAppInsightRolesToPrincipal 'Microsoft.Authorization/roleAssignmen
 // Assign role on Key Vault to the principal
 
 resource assignRolesOnKeyVaultToManagedIdentity 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(principalId, keyVault.id, roleDefinitions(keyVaultRole).id)
+  name: guid(principalId, keyVault.id, roleDefinitions(keyVaultRoleName).id)
   scope: keyVault
   properties: {
     #disable-next-line use-resource-id-functions
-    roleDefinitionId: roleDefinitions(keyVaultRole).id
+    roleDefinitionId: roleDefinitions(keyVaultRoleName).id
     principalId: principalId
     principalType: principalType
   }
@@ -91,7 +91,7 @@ resource assignRolesOnKeyVaultToManagedIdentity 'Microsoft.Authorization/roleAss
 // Assign roles on Storage Account to the principal
 
 resource assignRolesOnStorageAccountToManagedIdentity 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
-  for role in storageAccountRoles: if (storageAccountName != '') {
+  for role in storageAccountRoleNames: if (storageAccountName != '') {
     name: guid(principalId, storageAccount.id, roleDefinitions(role).id)
     scope: storageAccount
     properties: {


### PR DESCRIPTION
Had to suppress `use-resource-id-functions` linter rule because using `roleDefinitions` doesn't (yet) comply with this rule.